### PR TITLE
refactor: Chip, Fab, Typography, Divider 컴포넌트 수정

### DIFF
--- a/apps/workshop/src/stories/Button.stories.tsx
+++ b/apps/workshop/src/stories/Button.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
   argTypes: {
     size: {
       control: 'select',
-      options: ['xsmall', 'small', 'default'],
+      options: ['xxsmall', 'xsmall', 'small', 'default'],
       description: '버튼의 크기를 설정합니다.',
     },
   },

--- a/apps/workshop/src/stories/Chip.stories.tsx
+++ b/apps/workshop/src/stories/Chip.stories.tsx
@@ -1,29 +1,35 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { Chip } from "@repo/ui";
+import type { Meta, StoryObj } from '@storybook/react';
+import { Chip } from '@repo/ui';
+import { PlusOutlined } from '../../../../packages/ui/src/assets/icons';
 
 const meta = {
-  title: "Example/Chip",
+  title: 'Example/Chip',
   component: Chip,
   parameters: {
-    layout: "padded",
+    layout: 'centered',
   },
-  tags: ["autodocs"],
-  argTypes: {},
+  tags: ['autodocs'],
+  args: {
+    primary: false,
+    label: '라벨',
+  },
 } satisfies Meta<typeof Chip>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
-  args: {
-    label: "라벨",
-    primary: false,
-  },
+  args: {},
 };
 
 export const Primary: Story = {
   args: {
-    label: "라벨",
     primary: true,
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    icon: <PlusOutlined />,
   },
 };

--- a/apps/workshop/src/stories/Fab.stories.tsx
+++ b/apps/workshop/src/stories/Fab.stories.tsx
@@ -1,19 +1,22 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { Fab } from "@repo/ui";
+import type { Meta, StoryObj } from '@storybook/react';
+import { Fab } from '@repo/ui';
 
 const meta = {
-  title: "Example/Fab",
+  title: 'Example/Fab',
   component: Fab,
   parameters: {
-    layout: "padded",
+    layout: 'padded',
   },
-  tags: ["autodocs"],
+  tags: ['autodocs'],
   args: {
-    type: "circle",
+    shape: 'circle',
+    label: '펀딩 개설',
   },
   argTypes: {
-    icon: {
-      description: 'Default icon: "PlusOutlined"',
+    shape: {
+      control: 'select',
+      options: ['circle', 'capsule'],
+      description: '버튼의 모양을 설정합니다.',
     },
   },
 } satisfies Meta<typeof Fab>;
@@ -24,7 +27,7 @@ type Story = StoryObj<typeof Fab>;
 const FabTemplate: Story = {
   render: ({ label, ...arg }) => {
     return (
-      <div style={{ transform: "translate(0)", height: "100px" }}>
+      <div style={{ transform: 'translate(0)', height: '100px' }}>
         <Fab label={label} {...arg} />
       </div>
     );
@@ -33,15 +36,11 @@ const FabTemplate: Story = {
 
 export const Basic: Story = {
   ...FabTemplate,
-  args: {
-    label: "펀딩 개설",
-  },
 };
 
 export const Capsule: Story = {
   ...FabTemplate,
   args: {
-    type: "capsule",
-    label: "펀딩 개설",
+    shape: 'capsule',
   },
 };

--- a/apps/workshop/src/stories/Fab.stories.tsx
+++ b/apps/workshop/src/stories/Fab.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Fab } from '@repo/ui';
+import { PlusOutlined } from '../../../../packages/ui/src/assets/icons';
 
 const meta = {
   title: 'Example/Fab',
@@ -11,6 +12,7 @@ const meta = {
   args: {
     shape: 'circle',
     label: '펀딩 개설',
+    icon: <PlusOutlined />,
   },
   argTypes: {
     shape: {

--- a/apps/workshop/src/stories/Typography.stories.tsx
+++ b/apps/workshop/src/stories/Typography.stories.tsx
@@ -14,7 +14,8 @@ const meta = {
 } satisfies Meta<typeof Typography>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+
+type Story = StoryObj<typeof Typography>;
 
 export const Basic: Story = {
   args: {

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -4,7 +4,7 @@ import * as S from './button.css';
 
 export interface ButtonProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'prefix'> {
-  size?: 'xsmall' | 'small' | 'default';
+  size?: 'xxsmall' | 'xsmall' | 'small' | 'default';
   block?: boolean;
   primary?: boolean;
   disabled?: boolean;
@@ -40,7 +40,7 @@ export const Button = React.forwardRef<HTMLButtonElement, PropsWithChildren<Butt
         {...props}
       >
         {prefix && <span>{prefix}</span>}
-        <div className={S.text({ size })}>{children}</div>
+        {children}
         {suffix && <span>{suffix}</span>}
       </button>
     );

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -4,7 +4,8 @@ import * as S from './button.css';
 
 export interface ButtonProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'prefix'> {
-  size?: 'xxsmall' | 'xsmall' | 'small' | 'default';
+  size?: 'xsmall' | 'small' | 'default' | 'large';
+  align?: 'horizontal' | 'vertical';
   block?: boolean;
   primary?: boolean;
   disabled?: boolean;
@@ -22,6 +23,7 @@ export const Button = React.forwardRef<HTMLButtonElement, PropsWithChildren<Butt
       primary = false,
       disabled = false,
       borderless = false,
+      align = 'horizontal',
       className,
       prefix,
       suffix,
@@ -34,7 +36,7 @@ export const Button = React.forwardRef<HTMLButtonElement, PropsWithChildren<Butt
         ref={ref}
         disabled={disabled}
         className={clsx(
-          S.button({ size, block, primary, disabled, borderless }),
+          S.button({ size, align, block, primary, disabled, borderless }),
           className
         )}
         {...props}

--- a/packages/ui/src/components/Button/button.css.ts
+++ b/packages/ui/src/components/Button/button.css.ts
@@ -1,6 +1,12 @@
 import { recipe } from '@vanilla-extract/recipes';
 import { sprinkles } from '../../styles';
 
+const textSM = sprinkles({
+  fontSize: 'small',
+  fontWeight: '600',
+  lineHeight: '20px',
+});
+
 export const button = recipe({
   base: [
     sprinkles({
@@ -36,17 +42,35 @@ export const button = recipe({
         gap: '3x',
         height: '50px',
         paddingX: '7x',
+
+        fontSize: 'medium',
+        fontWeight: '700',
+        lineHeight: '24px',
       }),
-      small: sprinkles({
-        gap: '1x',
-        height: '44px',
-        paddingX: '5x',
-      }),
-      xsmall: sprinkles({
-        gap: '1x',
-        height: '32px',
-        paddingX: '5x',
-      }),
+      small: [
+        textSM,
+        sprinkles({
+          gap: '1x',
+          height: '44px',
+          paddingX: '5x',
+        }),
+      ],
+      xsmall: [
+        textSM,
+        sprinkles({
+          gap: '1x',
+          height: '32px',
+          paddingX: '5x',
+        }),
+      ],
+      xxsmall: [
+        textSM,
+        sprinkles({
+          gap: '1x',
+          height: '30px',
+          paddingX: '5x',
+        }),
+      ],
     },
     block: {
       true: sprinkles({ width: 'full' }),
@@ -63,28 +87,6 @@ export const button = recipe({
       true: {
         border: 'transparent',
       },
-    },
-  },
-});
-
-export const text = recipe({
-  variants: {
-    size: {
-      default: sprinkles({
-        fontSize: 'medium',
-        fontWeight: '700',
-        lineHeight: '24px',
-      }),
-      small: sprinkles({
-        fontSize: 'small',
-        fontWeight: '600',
-        lineHeight: '20px',
-      }),
-      xsmall: sprinkles({
-        fontSize: 'small',
-        fontWeight: '600',
-        lineHeight: '20px',
-      }),
     },
   },
 });

--- a/packages/ui/src/components/Button/button.css.ts
+++ b/packages/ui/src/components/Button/button.css.ts
@@ -38,7 +38,7 @@ export const button = recipe({
       ],
     },
     size: {
-      default: sprinkles({
+      large: sprinkles({
         gap: '3x',
         height: '50px',
         paddingX: '7x',
@@ -47,7 +47,7 @@ export const button = recipe({
         fontWeight: '700',
         lineHeight: '24px',
       }),
-      small: [
+      default: [
         textSM,
         sprinkles({
           gap: '1x',
@@ -55,7 +55,7 @@ export const button = recipe({
           paddingX: '5x',
         }),
       ],
-      xsmall: [
+      small: [
         textSM,
         sprinkles({
           gap: '1x',
@@ -63,7 +63,7 @@ export const button = recipe({
           paddingX: '5x',
         }),
       ],
-      xxsmall: [
+      xsmall: [
         textSM,
         sprinkles({
           gap: '1x',
@@ -71,6 +71,14 @@ export const button = recipe({
           paddingX: '5x',
         }),
       ],
+    },
+    align: {
+      horizontal: sprinkles({
+        flexDirection: 'row',
+      }),
+      vertical: sprinkles({
+        flexDirection: 'column',
+      }),
     },
     block: {
       true: sprinkles({ width: 'full' }),

--- a/packages/ui/src/components/Chip/Chip.tsx
+++ b/packages/ui/src/components/Chip/Chip.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import React from 'react';
-import { chipIcon, chip } from './chip.css';
+import { chip } from './chip.css';
 import { Typography } from '../Typography/Typography';
 import { Button } from '../Button/Button';
 
@@ -18,12 +18,12 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
       <Button
         ref={ref}
         borderless
-        size="xxsmall"
+        size="xsmall"
         primary={primary}
         className={clsx(chip({ primary }), className)}
+        prefix={icon}
         {...props}
       >
-        {icon && <span className={chipIcon({ primary })}>{icon}</span>}
         <Caption level={1}>{label}</Caption>
       </Button>
     );

--- a/packages/ui/src/components/Chip/Chip.tsx
+++ b/packages/ui/src/components/Chip/Chip.tsx
@@ -1,28 +1,31 @@
-import clsx from "clsx";
-import React from "react";
-import { chipIconStyles, chipStyles } from "./chip.css";
-import { Typography } from "../Typography/Typography";
-import { PlusOutlined } from "../../assets/icons";
+import clsx from 'clsx';
+import React from 'react';
+import { chipIcon, chip } from './chip.css';
+import { Typography } from '../Typography/Typography';
+import { Button } from '../Button/Button';
 
 const { Caption } = Typography;
 
-export interface ChipProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
   primary?: boolean;
+  icon?: React.ReactNode;
 }
 
 export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
-  ({ label, primary, className, ...props }: ChipProps, ref) => {
+  ({ label, primary, icon, className, ...props }: ChipProps, ref) => {
     return (
-      <button
+      <Button
         ref={ref}
-        className={clsx(chipStyles({ primary }), className)}
+        borderless
+        size="xxsmall"
+        primary={primary}
+        className={clsx(chip({ primary }), className)}
         {...props}
       >
-        <PlusOutlined className={chipIconStyles({ primary })} />
+        {icon && <span className={chipIcon({ primary })}>{icon}</span>}
         <Caption level={1}>{label}</Caption>
-      </button>
+      </Button>
     );
-  },
+  }
 );

--- a/packages/ui/src/components/Chip/chip.css.ts
+++ b/packages/ui/src/components/Chip/chip.css.ts
@@ -1,49 +1,32 @@
-import { recipe } from "@vanilla-extract/recipes";
-import { sprinkles, vars } from "../../styles";
+import { recipe } from '@vanilla-extract/recipes';
+import { sprinkles } from '../../styles';
 
-export const chipStyles = recipe({
-  base: [
-    sprinkles({
-      display: "flex",
-      alignItems: "center",
-      color: "gray700",
-      fontSize: "small",
-      borderRadius: "round",
-      paddingY: "2x",
-      paddingX: "5x",
-      height: "30px",
-    }),
-    {
-      border: 0,
-      columnGap: "3px",
-    },
-  ],
+export const chip = recipe({
+  base: {
+    columnGap: '3px',
+  },
   variants: {
     primary: {
-      true: {
-        color: vars.color.text.inverse,
-        background: vars.color.background.primary,
-      },
+      false: sprinkles({
+        background: 'gray100',
+      }),
     },
   },
 });
 
-export const chipIconStyles = recipe({
+export const chipIcon = recipe({
   base: [
     sprinkles({
-      fontSize: "18px",
+      fontSize: '18px',
     }),
-    {
-      lineHeight: 0,
-    },
   ],
   variants: {
     primary: {
       false: sprinkles({
-        color: "gray800",
+        color: 'gray800',
       }),
       true: sprinkles({
-        color: "white",
+        color: 'white',
       }),
     },
   },

--- a/packages/ui/src/components/Chip/chip.css.ts
+++ b/packages/ui/src/components/Chip/chip.css.ts
@@ -2,31 +2,18 @@ import { recipe } from '@vanilla-extract/recipes';
 import { sprinkles } from '../../styles';
 
 export const chip = recipe({
-  base: {
-    columnGap: '3px',
-  },
-  variants: {
-    primary: {
-      false: sprinkles({
-        background: 'gray100',
-      }),
-    },
-  },
-});
-
-export const chipIcon = recipe({
   base: [
     sprinkles({
       fontSize: '18px',
     }),
+    {
+      columnGap: '3px',
+    },
   ],
   variants: {
     primary: {
       false: sprinkles({
-        color: 'gray800',
-      }),
-      true: sprinkles({
-        color: 'white',
+        background: 'gray100',
       }),
     },
   },

--- a/packages/ui/src/components/Divider/Divider.tsx
+++ b/packages/ui/src/components/Divider/Divider.tsx
@@ -1,12 +1,13 @@
-import React from "react";
-import { dividerStyles } from "./divider.css";
+import React from 'react';
+import clsx from 'clsx';
+import { divider } from './divider.css';
 
 export interface DividerProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
   bolder?: boolean;
 }
 
 export const Divider = React.forwardRef<HTMLDivElement, DividerProps>(
-  ({ bolder = false, ...props }: DividerProps, ref) => {
-    return <div ref={ref} className={dividerStyles({ bolder })} {...props} />;
-  },
+  ({ bolder = false, className, ...props }: DividerProps, ref) => {
+    return <div ref={ref} className={clsx(divider({ bolder }), className)} {...props} />;
+  }
 );

--- a/packages/ui/src/components/Divider/divider.css.ts
+++ b/packages/ui/src/components/Divider/divider.css.ts
@@ -13,6 +13,7 @@ const base = style([
 ]);
 
 export const dividerStyles = recipe({
+export const divider = recipe({
   base,
   variants: {
     bolder: {

--- a/packages/ui/src/components/Divider/divider.css.ts
+++ b/packages/ui/src/components/Divider/divider.css.ts
@@ -1,24 +1,23 @@
-import { style } from "@vanilla-extract/css";
-import { recipe } from "@vanilla-extract/recipes";
-import { sprinkles, vars } from "../../styles";
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { sprinkles, vars } from '../../styles';
 
 const base = style([
   sprinkles({
-    width: "full",
+    width: 'full',
   }),
   {
-    height: "1px",
+    height: '1px',
     background: vars.color.divider.default,
   },
 ]);
 
-export const dividerStyles = recipe({
 export const divider = recipe({
   base,
   variants: {
     bolder: {
       true: {
-        height: "8px",
+        height: '8px',
         background: vars.color.divider.secondary,
       },
     },

--- a/packages/ui/src/components/Fab/Fab.tsx
+++ b/packages/ui/src/components/Fab/Fab.tsx
@@ -1,28 +1,30 @@
-import React from "react";
-import clsx from "clsx";
-import * as s from "./fab.css";
-import { PlusOutlined } from "../../assets/icons";
+import React from 'react';
+import clsx from 'clsx';
+import * as s from './fab.css';
+import { PlusOutlined } from '../../assets/icons';
+import { Button } from '../Button/Button';
 
-export type FabType = "circle" | "capsule";
+export type FabType = 'circle' | 'capsule';
 
-export interface FabProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface FabProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   shape?: FabType;
   label: string;
   icon?: React.ReactNode;
 }
 
 export const Fab = React.forwardRef<HTMLButtonElement, FabProps>(
-  ({ shape = "circle", label, icon, className, ...props }: FabProps, ref) => {
+  ({ shape = 'circle', label, icon, className, ...props }: FabProps, ref) => {
     return (
-      <button
+      <Button
+        primary
+        size="small"
         ref={ref}
         className={clsx(s.fabButton({ shape }), className)}
         {...props}
       >
         <span className={s.fabIcon({ shape })}>{icon || <PlusOutlined />}</span>
-        <span className={s.fabText({ shape })}>{label}</span>
-      </button>
+        <span className={s.fabText({ circle: shape === 'circle' })}>{label}</span>
+      </Button>
     );
-  },
+  }
 );

--- a/packages/ui/src/components/Fab/Fab.tsx
+++ b/packages/ui/src/components/Fab/Fab.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
 import * as s from './fab.css';
-import { PlusOutlined } from '../../assets/icons';
 import { Button } from '../Button/Button';
 
 export type FabType = 'circle' | 'capsule';
@@ -17,13 +16,14 @@ export const Fab = React.forwardRef<HTMLButtonElement, FabProps>(
     return (
       <Button
         primary
-        size="small"
+        size="default"
         ref={ref}
+        align={shape === 'circle' ? 'vertical' : 'horizontal'}
         className={clsx(s.fabButton({ shape }), className)}
+        prefix={icon}
         {...props}
       >
-        <span className={s.fabIcon({ shape })}>{icon || <PlusOutlined />}</span>
-        <span className={s.fabText({ circle: shape === 'circle' })}>{label}</span>
+        <span className={s.fabText({ shape })}>{label}</span>
       </Button>
     );
   }

--- a/packages/ui/src/components/Fab/fab.css.ts
+++ b/packages/ui/src/components/Fab/fab.css.ts
@@ -14,9 +14,9 @@ export const fabButton = recipe({
       circle: [
         sprinkles({
           flexDirection: 'column',
+          fontSize: '24px',
           width: '64px',
           height: '64px',
-          fontSize: '10px',
           letterSpacing: '-2%',
         }),
         {
@@ -28,6 +28,7 @@ export const fabButton = recipe({
       ],
       capsule: [
         sprinkles({
+          fontSize: '18px',
           paddingX: '7x',
         }),
         {
@@ -40,7 +41,7 @@ export const fabButton = recipe({
   },
 });
 
-export const fabIcon = recipe({
+export const fabText = recipe({
   base: [
     sprinkles({
       display: 'inline-block',
@@ -50,31 +51,16 @@ export const fabIcon = recipe({
     shape: {
       circle: [
         sprinkles({
-          fontSize: '24px',
-        }),
-      ],
-      capsule: sprinkles({
-        fontSize: '18px',
-      }),
-    },
-  },
-});
-
-export const fabText = recipe({
-  base: [
-    sprinkles({
-      display: 'inline-block',
-    }),
-  ],
-  variants: {
-    circle: {
-      true: [
-        sprinkles({
           fontSize: '10px',
         }),
         {
           lineHeight: '15px',
         },
+      ],
+      capsule: [
+        sprinkles({
+          fontSize: '14px',
+        }),
       ],
     },
   },

--- a/packages/ui/src/components/Fab/fab.css.ts
+++ b/packages/ui/src/components/Fab/fab.css.ts
@@ -1,47 +1,39 @@
-import { recipe } from "@vanilla-extract/recipes";
-import { sprinkles } from "../../styles";
+import { recipe } from '@vanilla-extract/recipes';
+import { sprinkles } from '../../styles';
 
 export const fabButton = recipe({
   base: [
     sprinkles({
-      position: "fixed",
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      color: "white",
-      borderRadius: "round",
-      background: "black",
-      boxShadow: "default",
+      position: 'fixed',
+      boxShadow: 'default',
+      gap: '1x',
     }),
-    {
-      border: 0,
-    },
   ],
   variants: {
     shape: {
       circle: [
         sprinkles({
-          flexDirection: "column",
-          width: "64px",
-          height: "64px",
-          fontSize: "10px",
-          letterSpacing: "-2%",
+          flexDirection: 'column',
+          width: '64px',
+          height: '64px',
+          fontSize: '10px',
+          letterSpacing: '-2%',
         }),
         {
           lineHeight: 1.5,
-          right: "20px",
-          bottom: "20px",
+          right: '20px',
+          bottom: '20px',
+          padding: 0,
         },
       ],
       capsule: [
         sprinkles({
-          height: "44px",
-          paddingX: "7x",
+          paddingX: '7x',
         }),
         {
-          right: "50%",
-          bottom: "40px",
-          transform: "translateX(50%)",
+          right: '50%',
+          bottom: '40px',
+          transform: 'translateX(50%)',
         },
       ],
     },
@@ -51,22 +43,18 @@ export const fabButton = recipe({
 export const fabIcon = recipe({
   base: [
     sprinkles({
-      display: "inline-block",
+      display: 'inline-block',
     }),
   ],
   variants: {
     shape: {
       circle: [
         sprinkles({
-          fontSize: "24px",
+          fontSize: '24px',
         }),
-        {
-          marginBottom: "3px",
-        },
       ],
       capsule: sprinkles({
-        fontSize: "18px",
-        marginRight: "1x",
+        fontSize: '18px',
       }),
     },
   },
@@ -75,23 +63,19 @@ export const fabIcon = recipe({
 export const fabText = recipe({
   base: [
     sprinkles({
-      display: "inline-block",
+      display: 'inline-block',
     }),
   ],
   variants: {
-    shape: {
-      circle: [
+    circle: {
+      true: [
         sprinkles({
-          fontSize: "10px",
+          fontSize: '10px',
         }),
         {
-          lineHeight: "15px",
+          lineHeight: '15px',
         },
       ],
-      capsule: sprinkles({
-        fontSize: "14px",
-        lineHeight: "20px",
-      }),
     },
   },
 });

--- a/packages/ui/src/components/Typography/Typography.tsx
+++ b/packages/ui/src/components/Typography/Typography.tsx
@@ -1,18 +1,27 @@
-import React from "react";
-import clsx from "clsx";
 import {
-  headingStyles,
-  CaptionStyles,
-  TextStyles,
-  FootStyles,
-} from "./typography.css";
+  ElementType,
+  HTMLAttributes,
+  ParamHTMLAttributes,
+  PropsWithChildren,
+  forwardRef,
+} from 'react';
+import clsx from 'clsx';
+import * as S from './typography.css';
 
 /**
  * Typography Article
  */
-export const Typography = ({ children }: React.PropsWithChildren) => {
-  return <article>{children}</article>;
-};
+export type TypographyProps = PropsWithChildren<HTMLAttributes<HTMLElement>>;
+
+export const TypographyRoot = forwardRef<HTMLElement, TypographyProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <article ref={ref} className={className} {...props}>
+        {children}
+      </article>
+    );
+  }
+);
 
 /**
  * Typography Heading
@@ -22,27 +31,27 @@ export const Typography = ({ children }: React.PropsWithChildren) => {
  * - level `3`: SubHeading 1, SubHeading 2
  * - level `4`: Title 1
  */
-export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+export interface HeadingProps
+  extends PropsWithChildren<HTMLAttributes<HTMLHeadingElement>> {
   level?: 1 | 2 | 3 | 4;
   strong?: boolean;
 }
 
-const Heading = React.forwardRef<
-  HTMLHeadingElement,
-  React.PropsWithChildren<HeadingProps>
->(({ level = 1, strong = true, className, children, ...props }, ref) => {
-  const HeadingLevel = `h${level}` as React.ElementType;
+const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
+  ({ level = 1, strong = true, className, children, ...props }, ref) => {
+    const HeadingLevel = `h${level}` as ElementType;
 
-  return (
-    <HeadingLevel
-      ref={ref}
-      className={clsx(headingStyles({ level, strong }), className)}
-      {...props}
-    >
-      {children}
-    </HeadingLevel>
-  );
-});
+    return (
+      <HeadingLevel
+        ref={ref}
+        className={clsx(S.heading({ level, strong }), className)}
+        {...props}
+      >
+        {children}
+      </HeadingLevel>
+    );
+  }
+);
 
 /**
  * Typography Body Text
@@ -51,25 +60,21 @@ const Heading = React.forwardRef<
  * - level `2`: Body text 2
  * - level `3`: Body text 3
  */
-export interface TextProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface TextProps
+  extends PropsWithChildren<ParamHTMLAttributes<HTMLParagraphElement>> {
   level?: 1 | 2 | 3;
   inline?: boolean;
 }
 
-const Text = React.forwardRef<
-  HTMLDivElement,
-  React.PropsWithChildren<TextProps>
->(({ level = 1, inline = false, className, children, ...props }, ref) => {
-  return (
-    <div
-      ref={ref}
-      className={clsx(TextStyles({ level, inline }), className)}
-      {...props}
-    >
-      {children}
-    </div>
-  );
-});
+const Text = forwardRef<HTMLParagraphElement, TextProps>(
+  ({ level = 1, inline = false, className, children, ...props }, ref) => {
+    return (
+      <p ref={ref} className={clsx(S.Text({ level, inline }), className)} {...props}>
+        {children}
+      </p>
+    );
+  }
+);
 
 /**
  * Typography Caption
@@ -80,25 +85,20 @@ const Text = React.forwardRef<
  * - level `4`: Caption 4
  */
 export interface CaptionProps
-  extends React.HTMLAttributes<HTMLParagraphElement> {
+  extends PropsWithChildren<HTMLAttributes<HTMLParagraphElement>> {
   level?: 1 | 2 | 3 | 4;
   inline?: boolean;
 }
 
-const Caption = React.forwardRef<
-  HTMLParagraphElement,
-  React.PropsWithChildren<CaptionProps>
->(({ level = 1, inline = false, className, children, ...props }, ref) => {
-  return (
-    <p
-      ref={ref}
-      className={clsx(CaptionStyles({ level, inline }), className)}
-      {...props}
-    >
-      {children}
-    </p>
-  );
-});
+const Caption = forwardRef<HTMLParagraphElement, CaptionProps>(
+  ({ level = 1, inline = false, className, children, ...props }, ref) => {
+    return (
+      <p ref={ref} className={clsx(S.Caption({ level, inline }), className)} {...props}>
+        {children}
+      </p>
+    );
+  }
+);
 
 /**
  * Typography Foot Note
@@ -107,23 +107,27 @@ const Caption = React.forwardRef<
  * - level `2`: Foot 2
  * - level `3`: Foot 3
  */
-export interface FootProps extends React.HTMLAttributes<HTMLParagraphElement> {
+export interface FootProps
+  extends PropsWithChildren<HTMLAttributes<HTMLParagraphElement>> {
   level?: 1 | 2 | 3;
   className?: string;
 }
 
-const Foot = React.forwardRef<
-  HTMLParagraphElement,
-  React.PropsWithChildren<FootProps>
->(({ level = 1, children, className, ...props }, ref) => {
-  return (
-    <p ref={ref} className={clsx(FootStyles({ level }), className)} {...props}>
-      {children}
-    </p>
-  );
+const Foot = forwardRef<HTMLParagraphElement, FootProps>(
+  ({ level = 1, children, className, ...props }, ref) => {
+    return (
+      <p ref={ref} className={clsx(S.Foot({ level }), className)} {...props}>
+        {children}
+      </p>
+    );
+  }
+);
+
+const Compound = Object.assign(TypographyRoot, {
+  Heading,
+  Text,
+  Caption,
+  Foot,
 });
 
-Typography.Heading = Heading;
-Typography.Text = Text;
-Typography.Caption = Caption;
-Typography.Foot = Foot;
+export { Compound as Typography };

--- a/packages/ui/src/components/Typography/Typography.tsx
+++ b/packages/ui/src/components/Typography/Typography.tsx
@@ -14,9 +14,9 @@ import * as S from './typography.css';
 export type TypographyProps = PropsWithChildren<HTMLAttributes<HTMLElement>>;
 
 export const TypographyRoot = forwardRef<HTMLElement, TypographyProps>(
-  ({ className, children, ...props }, ref) => {
+  ({ children, ...props }, ref) => {
     return (
-      <article ref={ref} className={className} {...props}>
+      <article ref={ref} {...props}>
         {children}
       </article>
     );

--- a/packages/ui/src/components/Typography/typography.css.ts
+++ b/packages/ui/src/components/Typography/typography.css.ts
@@ -1,42 +1,42 @@
-import { style } from "@vanilla-extract/css";
-import { recipe } from "@vanilla-extract/recipes";
-import { sprinkles } from "../../styles";
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { sprinkles } from '../../styles';
 
 /**
  * Typography Heading
  */
-export const headingStyles = recipe({
+export const heading = recipe({
   base: [
     sprinkles({
-      letterSpacing: "-2%",
+      letterSpacing: '-2%',
     }),
   ],
   variants: {
     level: {
       1: sprinkles({
-        fontSize: "24px",
-        lineHeight: "32px",
+        fontSize: '24px',
+        lineHeight: '32px',
       }),
       2: sprinkles({
-        fontSize: "20px",
-        lineHeight: "28px",
+        fontSize: '20px',
+        lineHeight: '28px',
       }),
       3: sprinkles({
-        fontSize: "18px",
-        lineHeight: "26px",
+        fontSize: '18px',
+        lineHeight: '26px',
       }),
       4: sprinkles({
-        fontSize: "16px",
-        letterSpacing: "-1%",
-        lineHeight: "24px",
+        fontSize: '16px',
+        letterSpacing: '-1%',
+        lineHeight: '24px',
       }),
     },
     strong: {
       true: sprinkles({
-        fontWeight: "700",
+        fontWeight: '700',
       }),
       false: sprinkles({
-        fontWeight: "500",
+        fontWeight: '500',
       }),
     },
   },
@@ -47,7 +47,7 @@ export const headingStyles = recipe({
         strong: false,
       },
       style: sprinkles({
-        fontWeight: "600",
+        fontWeight: '600',
       }),
     },
   ],
@@ -56,31 +56,31 @@ export const headingStyles = recipe({
 /**
  * Typography Text
  */
-export const TextStyles = recipe({
+export const Text = recipe({
   base: style([
     sprinkles({
-      fontSize: "16px",
-      letterSpacing: "-1%",
+      fontSize: '16px',
+      letterSpacing: '-1%',
     }),
   ]),
   variants: {
     level: {
       1: sprinkles({
-        fontWeight: "600",
-        lineHeight: "26px",
+        fontWeight: '600',
+        lineHeight: '26px',
       }),
       2: sprinkles({
-        lineHeight: "26px",
-        fontWeight: "500",
+        lineHeight: '26px',
+        fontWeight: '500',
       }),
       3: sprinkles({
-        fontWeight: "500",
-        lineHeight: "28px",
+        fontWeight: '500',
+        lineHeight: '28px',
       }),
     },
     inline: {
       true: sprinkles({
-        display: "inline-block",
+        display: 'inline-block',
       }),
     },
   },
@@ -89,33 +89,33 @@ export const TextStyles = recipe({
 /**
  * Typography Caption
  */
-export const CaptionStyles = recipe({
+export const Caption = recipe({
   base: style([
     sprinkles({
-      fontSize: "14px",
-      lineHeight: "20px",
-      letterSpacing: "-1%",
+      fontSize: '14px',
+      lineHeight: '20px',
+      letterSpacing: '-1%',
     }),
   ]),
   variants: {
     level: {
       1: sprinkles({
-        fontWeight: "600",
+        fontWeight: '600',
       }),
       2: sprinkles({
-        fontWeight: "500",
+        fontWeight: '500',
       }),
       3: sprinkles({
-        fontWeight: "400",
+        fontWeight: '400',
       }),
       4: sprinkles({
-        fontWeight: "500",
-        letterSpacing: "-4%",
+        fontWeight: '500',
+        letterSpacing: '-4%',
       }),
     },
     inline: {
       true: sprinkles({
-        display: "inline-block",
+        display: 'inline-block',
       }),
     },
   },
@@ -124,27 +124,27 @@ export const CaptionStyles = recipe({
 /**
  * Typography Foot
  */
-export const FootStyles = recipe({
+export const Foot = recipe({
   base: style([
     sprinkles({
-      fontSize: "12px",
-      lineHeight: "20px",
-      letterSpacing: "-1%",
+      fontSize: '12px',
+      lineHeight: '20px',
+      letterSpacing: '-1%',
     }),
   ]),
   variants: {
     level: {
       1: sprinkles({
-        fontWeight: "600",
+        fontWeight: '600',
       }),
       2: sprinkles({
-        fontWeight: "500",
+        fontWeight: '500',
       }),
       3: sprinkles({
-        fontSize: "10px",
-        fontWeight: "500",
-        lineHeight: "16px",
-        letterSpacing: "-2%",
+        fontSize: '10px',
+        fontWeight: '500',
+        lineHeight: '16px',
+        letterSpacing: '-2%',
       }),
     },
   },

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,20 +1,12 @@
-export { Button, type ButtonProps } from './Button/Button';
-export { ButtonGroup, type ButtonGroupProps } from './ButtonGroup/ButtonGroup';
 export { BottomSheet, type BottomSheetProps } from './BottomSheet/BottomSheet';
-export { Fab, type FabProps } from './Fab/Fab';
-export { Divider, type DividerProps } from './Divider/Divider';
 export { Input, type InputProps } from './Input/Input';
 export { InputNumber, type InputNumberProps } from './InputNumber/InputNumber';
 export { InputSelect, type InputSelectProps } from './InputSelect/InputSelect';
+export { Button } from './Button/Button';
+export { ButtonGroup } from './ButtonGroup/ButtonGroup';
+export { Fab } from './Fab/Fab';
+export { Divider } from './Divider/Divider';
 export { Textarea, type TextareaProps } from './Textarea/Textarea';
-export {
-  Typography,
-  type HeadingProps,
-  type TextProps,
-  type CaptionProps,
-  type FootProps,
-} from './Typography/Typography';
-export { Chip, type ChipProps } from './Chip/Chip';
 export {
   IndicatorFunding,
   type IndicatorFundingProps,
@@ -45,6 +37,9 @@ export {
   type MainVisualCardProps,
 } from './MainVisualCard/MainVisualCard';
 export { DatePicker, type DatePickerProps } from './DatePicker/DatePicker';
+export { Typography } from './Typography/Typography';
+export { Chip } from './Chip/Chip';
+export { DatePicker } from './DatePicker/DatePicker';
 
 /* styles */
 export * as globalCSS from '../styles/global.css';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -36,7 +36,6 @@ export {
   MainVisualCard,
   type MainVisualCardProps,
 } from './MainVisualCard/MainVisualCard';
-export { DatePicker, type DatePickerProps } from './DatePicker/DatePicker';
 export { Typography } from './Typography/Typography';
 export { Chip } from './Chip/Chip';
 export { DatePicker } from './DatePicker/DatePicker';


### PR DESCRIPTION
# **Motivation 🤔**
### 컴포넌트 디자인 시스템 컴포넌트 개선
- Button
  - Chip
  - Fab
- Typography
- Divider

# **Key Changes 🔑**
- Button 컴포넌트를 재사용하여 Chip, Fab 컴포넌트 구현
  - Button 컴포넌트 사이즈 케이스 추가
  - Fab 두가지 형태(캡슐, 원형) 로 변형 가능하도록 `shape` props추가  
  - Chip 아이콘 optional로 변경 (사용하지 않는 케이스가 존재)
- Typography 컴포넌트 컴파운드 패턴 적용
- Style 네이밍 컨벤션 적용
- Storybook 작업

# **To Reviews 🙏🏻**
@dgd03146 
- Button 컴포넌트 재사용이 적절하게 반영되었는지 확인
- 컴파운드 패턴이 및 타입이 적절하게 적용되었는지 확인